### PR TITLE
Allow safe running in simulator

### DIFF
--- a/src/ios/RouterAndRoutes.h
+++ b/src/ios/RouterAndRoutes.h
@@ -15,6 +15,10 @@
 #import <net/if_dl.h>
 #import <sys/sysctl.h>
 
+#if TARGET_IPHONE_SIMULATOR
+#include <net/route.h>
+#endif
+
 #define RTF_PRCLONING	0x10000		/* protocol requires cloning */
 #define RTF_WASCLONED	0x20000		/* route generated through cloning */
 #define RTF_PROTO3	0x40000		/* protocol specific routing flag */
@@ -38,6 +42,7 @@
 #define RTA_AUTHOR	0x40	/* sockaddr for author of redirect */
 #define RTA_BRD		0x80	/* for NEWADDR, broadcast or p-p dest addr */
 
+#if !(TARGET_IPHONE_SIMULATOR)
 
 struct rt_metrics {
     u_int32_t	rmx_locks;	/* Kernel must leave these values alone */
@@ -68,6 +73,8 @@ struct rt_msghdr2 {
     u_int32_t rtm_inits;		/* which metrics we are initializing */
     struct rt_metrics rtm_rmx;	/* metrics themselves */
 };
+
+#endif
 
 @interface Route_Info : NSObject
 {


### PR DESCRIPTION
I had an issue with redefinitions when running in the iOS simulator (Cordova 6, XCode 7.2, iOS 9.2). This PR resolves those build issues for me whilst still running on the device.
